### PR TITLE
Expose autoscrollAreaHeight as a prop instead of a constant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ npm i react-native-sortable-list --save
 - **style** (Object, Array)
 - **contentContainerStyle** (Object, Array) these styles will be applied to the inner scroll view content container
 - **sortingEnabled** (boolean) when false, rows are not sortable. The default value is true.
-- **scrollEnabled** (boolean) when false, the content does not scrollable. The default value is true.<br /><br />
+- **scrollEnabled** (boolean) when false, the content does not scrollable. The default value is true.
+- **autoscrollAreaHeight** (number) determines the height of the area at the top and the bottom of the list that will trigger autoscrolling. Defaults to 60.<br />
+<br />
 - **renderRow** (function)<br />
 `({key, index, data, disabled, active}) => renderable`<br />
-Takes a row key, row index, data entry from the data source and its statuses disabled, active and should return a renderable component to be rendered as the row.<br /><br />
+Takes a row key, row index, data entry from the data source and its statuses disabled, active and should return a renderable component to be rendered as the row.
+<br />
+<br />
 - **onChangeOrder** (function)<br />
 `(nextOrder) => void`<br />
 Called when rows were reordered, takes an array of rows keys of the next rows order.

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -3,7 +3,6 @@ import {Animated, ScrollView, View, StyleSheet, Platform} from 'react-native';
 import {shallowEqual, swapArrayElements} from './utils';
 import Row from './Row';
 
-const AUTOSCROLL_AREA_HEIGTH = 60;
 const AUTOSCROLL_INTERVAL = 100;
 const ZINDEX = Platform.OS === 'ios' ? 'zIndex' : 'elevation';
 
@@ -27,11 +26,13 @@ export default class SortableList extends Component {
     onChangeOrder: PropTypes.func,
     onActivateRow: PropTypes.func,
     onReleaseRow: PropTypes.func,
+    autoscrollAreaHeight: PropTypes.number,
   };
 
   static defaultProps = {
     sortingEnabled: true,
     scrollEnabled: true,
+    autoscrollAreaHeight: 60,
   }
 
   /**
@@ -345,8 +346,8 @@ export default class SortableList extends Component {
   _scrollOnMove(e) {
     const {pageY} = e.nativeEvent;
     const {containerLayout} = this.state;
-    const inAutoScrollUpArea = pageY < containerLayout.pageY + AUTOSCROLL_AREA_HEIGTH;
-    const inAutoScrollDownArea = pageY > containerLayout.pageY + containerLayout.height - AUTOSCROLL_AREA_HEIGTH;
+    const inAutoScrollUpArea = pageY < containerLayout.pageY + this.props.autoscrollAreaHeight;
+    const inAutoScrollDownArea = pageY > containerLayout.pageY + containerLayout.height - this.props.autoscrollAreaHeight;
 
     if (!inAutoScrollUpArea &&
       !inAutoScrollDownArea &&


### PR DESCRIPTION
Defaults to 60, but can be changed. Especially useful when row height or list is small.