### PR TITLE
Stop autoScroll if scroll disabled

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -471,7 +471,9 @@ export default class SortableList extends Component {
     this._movingDirectionChanged = prevMovingDirection !== this._movingDirection;
     this._setOrderOnMove();
 
-    this._scrollOnMove(e);
+    if (this.props.scrollEnabled) {
+      this._scrollOnMove(e);
+    }
   };
 
   _onScroll = ({nativeEvent: {contentOffset}}) => {


### PR DESCRIPTION
Not sure if it was intended behavior, but scrolling still seems to happen even if scrollEnabled=false
If it was intended, could we introduce a new prop of autoScrollEnabled?