### PR TITLE
Added refreshControl to ScrollView

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Called when the active row was released.
 - **onPressRow** (function)<br />
 `(key) => void`<br />
 Called when a row was pressed.
+- **refreshControl** (Object)<br />
+A RefreshControl that works the same way as a ScrollView's refreshControl.
 
 #### Methods
 - **scrollBy(dy?, animated?)** scrolls by a given y offset, either immediately or with a smooth animation

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import {Animated, ScrollView, View, StyleSheet, Platform} from 'react-native';
+import {Animated, ScrollView, View, StyleSheet, Platform, refreshControl} from 'react-native';
 import {shallowEqual, swapArrayElements} from './utils';
 import Row from './Row';
 
@@ -21,6 +21,7 @@ export default class SortableList extends Component {
     sortingEnabled: PropTypes.bool,
     scrollEnabled: PropTypes.bool,
     horizontal: PropTypes.bool,
+    refreshControl: PropTypes.object,
 
     renderRow: PropTypes.func.isRequired,
 
@@ -154,6 +155,7 @@ export default class SortableList extends Component {
     const {contentHeight, contentWidth, scrollEnabled} = this.state;
     const containerStyle = StyleSheet.flatten([this.props.style, this.state.style]);
     const innerContainerStyle = [styles.container];
+    let refreshControl = this.props.refreshControl;
 
     if (horizontal) {
       innerContainerStyle.push({width: contentWidth});
@@ -161,9 +163,19 @@ export default class SortableList extends Component {
       innerContainerStyle.push({height: contentHeight});
     }
 
+    if(refreshControl) {
+      refreshControl=(
+        <RefreshControl
+          {...this.props.refreshControl.props}
+          enabled={scrollEnabled}
+        />
+      )
+    }
+
     return (
       <Animated.View style={containerStyle} ref={this._onRefContainer}>
         <ScrollView
+          refreshControl={refreshControl}
           ref={this._onRefScrollView}
           horizontal={horizontal}
           contentContainerStyle={contentContainerStyle}

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import {Animated, ScrollView, View, StyleSheet, Platform, refreshControl} from 'react-native';
+import {Animated, ScrollView, View, StyleSheet, Platform, RefreshControl} from 'react-native';
 import {shallowEqual, swapArrayElements} from './utils';
 import Row from './Row';
 


### PR DESCRIPTION
Related to #38

Found a way to make android work as well as ios, with or without the refreshControl. 

The `enabled` prop of the `RefreshControl` component prevents android's pull-down to appear when sorting. 