### PR TITLE
Remove opacity animation upon mounting and updating

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -57,10 +57,7 @@ export default class SortableList extends Component {
     activeRowIndex: null,
     releasedRowKey: null,
     sortingEnabled: this.props.sortingEnabled,
-    scrollEnabled: this.props.scrollEnabled,
-    style: {
-      opacity: new Animated.Value(0),
-    },
+    scrollEnabled: this.props.scrollEnabled
   };
 
   componentDidMount() {
@@ -72,16 +69,14 @@ export default class SortableList extends Component {
     const {data: nextData, order: nextOrder} = nextProps;
 
     if (data && nextData && !shallowEqual(data, nextData)) {
-      this._animateRowsDisappearance(() => {
-        uniqueRowKey.id++;
-        this._areRowsAnimated = false;
-        this._rowsLayouts = [];
-        this.setState({
-          data: nextData,
-          containerLayout: null,
-          rowsLayouts: null,
-          order: nextOrder || Object.keys(nextData)
-        });
+      uniqueRowKey.id++;
+      this._areRowsAnimated = false;
+      this._rowsLayouts = [];
+      this.setState({
+        data: nextData,
+        containerLayout: null,
+        rowsLayouts: null,
+        order: nextOrder || Object.keys(nextData)
       });
 
     } else if (order && nextOrder && !shallowEqual(order, nextOrder)) {
@@ -150,9 +145,8 @@ export default class SortableList extends Component {
   }
 
   render() {
-    const {contentContainerStyle, horizontal} = this.props;
+    const {contentContainerStyle, horizontal, style: containerStyle} = this.props;
     const {contentHeight, contentWidth, scrollEnabled} = this.state;
-    const containerStyle = StyleSheet.flatten([this.props.style, this.state.style]);
     const innerContainerStyle = [styles.container];
 
     if (horizontal) {
@@ -267,23 +261,9 @@ export default class SortableList extends Component {
             rowsLayouts: rowsLayoutsByKey,
             contentHeight,
             contentWidth,
-          }, () => {
-            this._animateRowsAppearance(() => (this._areRowsAnimated = true));
-          });
+          }, () => (this._areRowsAnimated = true));
         });
       });
-  }
-
-  _animateRowsAppearance(onAnimationEnd) {
-    Animated.timing(this.state.style.opacity, {
-      toValue: 1,
-    }).start(onAnimationEnd);
-  }
-
-  _animateRowsDisappearance(onAnimationEnd) {
-    Animated.timing(this.state.style.opacity, {
-      toValue: 0,
-    }).start(onAnimationEnd);
   }
 
   _scroll(animated) {


### PR DESCRIPTION
Based from issue [#42](https://github.com/gitim/react-native-sortable-list/issues/42).

Removed the animations completely as per request. I figure if the user wants add in animation they can either wrap it in another component or insert it into the row component.