### PR TITLE
Stretch row so child items fill container list

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -153,12 +153,18 @@ export default class Row extends Component {
   }
 
   render() {
-    const {children, style} = this.props;
+    const {children, style, horizontal} = this.props;
+    const rowStyle = [
+      style,
+      styles.container,
+      this._animatedLocation.getLayout(),
+      horizontal ? {top: 0, bottom: 0} : {left: 0, right: 0}
+    ];
 
     return (
       <Animated.View
         {...this._panResponder.panHandlers}
-        style={[style, styles.container, this._animatedLocation.getLayout()]}
+        style={rowStyle}
         onLayout={this._onLayout}>
         {children}
       </Animated.View>

--- a/src/Row.js
+++ b/src/Row.js
@@ -156,7 +156,7 @@ export default class Row extends Component {
     const {children, style, horizontal} = this.props;
     const rowStyle = [
       style, styles.container, this._animatedLocation.getLayout(),
-      horizontal ? {top: 0, bottom: 0} : {left: 0, right: 0}
+      horizontal ? styles.horizontalContainer : styles.verticalContainer,
     ];
 
     return (
@@ -234,5 +234,13 @@ export default class Row extends Component {
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
+  },
+  horizontalContainer: {
+    top: 0,
+    bottom: 0,
+  },
+  verticalContainer: {
+    left: 0,
+    right: 0,
   },
 });

--- a/src/Row.js
+++ b/src/Row.js
@@ -155,9 +155,7 @@ export default class Row extends Component {
   render() {
     const {children, style, horizontal} = this.props;
     const rowStyle = [
-      style,
-      styles.container,
-      this._animatedLocation.getLayout(),
+      style, styles.container, this._animatedLocation.getLayout(),
       horizontal ? {top: 0, bottom: 0} : {left: 0, right: 0}
     ];
 

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -209,15 +209,6 @@ export default class SortableList extends Component {
     const {horizontal, rowActivationTime, sortingEnabled, renderRow} = this.props;
     const {animated, order, data, activeRowKey, releasedRowKey, rowsLayouts} = this.state;
 
-    let rowHeight = 0;
-    let rowWidth = 0;
-
-    if (rowsLayouts) {
-      Object.keys(rowsLayouts).forEach((key) => {
-        rowHeight = Math.max(rowHeight, rowsLayouts[key].height);
-        rowWidth = Math.max(rowWidth, rowsLayouts[key].width);
-      });
-    }
 
     let nextX = 0;
     let nextY = 0;
@@ -228,11 +219,9 @@ export default class SortableList extends Component {
 
       if (rowsLayouts) {
         if (horizontal) {
-          style.height = rowHeight;
           location.x = nextX;
           nextX += rowsLayouts[key].width;
         } else {
-          style.width = rowWidth;
           location.y = nextY;
           nextY += rowsLayouts[key].height;
         }


### PR DESCRIPTION
Currently the workaround is to pass the width of the parent container to the child rows. Would be ideal if children rows just auto-fit into the width (or height, if horizonal list) of their parents.

Thanks @gitim for all the work you've put into this library, btw!