### PR TITLE
[Props] update deprecated View.propTypes to ViewPropTypes

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {ScrollView, View, StyleSheet, Platform, RefreshControl} from 'react-native';
+import {ScrollView, View, StyleSheet, Platform, RefreshControl, ViewPropTypes} from 'react-native';
 import {shallowEqual, swapArrayElements} from './utils';
 import Row from './Row';
 
@@ -17,8 +17,8 @@ export default class SortableList extends Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
     order: PropTypes.arrayOf(PropTypes.any),
-    style: View.propTypes.style,
-    contentContainerStyle: View.propTypes.style,
+    style: ViewPropTypes.style,
+    contentContainerStyle: ViewPropTypes.style,
     sortingEnabled: PropTypes.bool,
     scrollEnabled: PropTypes.bool,
     horizontal: PropTypes.bool,


### PR DESCRIPTION
`View.propTypes` has been deprecated in the latest versions of React Native. Running release builds will cause errors such as "View.propTypes.style is undefined".

This is a simple change use to replace it with the new React Native ViewPropTypes API.

(oops I didn't see #68 and #69 - feel free to close/decline if that gets updated)