### PR TITLE
Prevent crash by checking for undefined rowLayouts[key]

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -224,10 +224,10 @@ export default class SortableList extends Component {
       if (rowsLayouts) {
         if (horizontal) {
           location.x = nextX;
-          nextX += rowsLayouts[key].width;
+          nextX += rowsLayouts[key] ? rowsLayouts[key].width : 0;
         } else {
           location.y = nextY;
-          nextY += rowsLayouts[key].height;
+          nextY += rowsLayouts[key] ? rowsLayouts[key].height : 0;
         }
       }
 


### PR DESCRIPTION
Was running into a crash when using this in combination with react-navigation and the view with SortableList was not currently on the screen but still being updated. 