### PR TITLE
Return the new list order on release row

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Called when rows were reordered, takes an array of rows keys of the next rows or
 `(key) => void`<br />
 Called when a row was activated (user long tapped).
 - **onReleaseRow?** (function)<br />
-`(key) => void`<br />
-Called when the active row was released.
+`(key, currentOrder) => void`<br />
+Called when the active row was released. Returns the key and the new list order.
 - **onPressRow?** (function)<br />
 `(key) => void`<br />
 Called when a row was pressed.

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -591,7 +591,7 @@ export default class SortableList extends Component {
     }));
 
     if (this.props.onReleaseRow) {
-      this.props.onReleaseRow(rowKey);
+      this.props.onReleaseRow(rowKey, this.state.order);
     }
   };
 


### PR DESCRIPTION
`onChangeOrder` is called each time a row is swapped with another one, while dragging. 

This triggers the rerendering of the whole list, and the sorting process by the user is interrupted.

Another solution would be to wait for the end of the dragging operation, and use the `onReleaseRow` callback.

In order to persist the order (for instance in a Redux store), the callback thus needs to get the new list order.