### PR TITLE
Add Drag View height/width props to display the last item while dragging it down

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -20,6 +20,8 @@ export default class SortableList extends Component {
     style: ViewPropTypes.style,
     contentContainerStyle: ViewPropTypes.style,
     innerContainerStyle: ViewPropTypes.style,
+    draggableScreenHeight: PropTypes.number,
+    draggableScreenWidth: PropTypes.number,
     sortingEnabled: PropTypes.bool,
     scrollEnabled: PropTypes.bool,
     horizontal: PropTypes.bool,
@@ -43,6 +45,8 @@ export default class SortableList extends Component {
     sortingEnabled: true,
     scrollEnabled: true,
     autoscrollAreaSize: 60,
+    draggableScreenHeight: 0,
+    draggableScreenWidth: 0,
     manuallyActivateRows: false,
     showsVerticalScrollIndicator: true,
     showsHorizontalScrollIndicator: true
@@ -184,12 +188,12 @@ export default class SortableList extends Component {
   }
 
   render() {
-    let {contentContainerStyle, innerContainerStyle, horizontal, style, showsVerticalScrollIndicator, showsHorizontalScrollIndicator} = this.props;
+    let {contentContainerStyle, innerContainerStyle, horizontal, style, showsVerticalScrollIndicator, showsHorizontalScrollIndicator, draggableScreenHeight, draggableScreenWidth} = this.props;
     const {animated, contentHeight, contentWidth, scrollEnabled} = this.state;
     const containerStyle = StyleSheet.flatten([style, {opacity: Number(animated)}])
     innerContainerStyle = [
       styles.rowsContainer,
-      horizontal ? {width: contentWidth} : {height: contentHeight},
+      horizontal ? {width: Math.max(contentWidth, draggableScreenWidth)} : {height: Math.max(contentHeight, draggableScreenHeight)},
       innerContainerStyle
     ];
     let {refreshControl} = this.props;

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -20,8 +20,8 @@ export default class SortableList extends Component {
     style: ViewPropTypes.style,
     contentContainerStyle: ViewPropTypes.style,
     innerContainerStyle: ViewPropTypes.style,
-    draggableScreenHeight: PropTypes.number,
-    draggableScreenWidth: PropTypes.number,
+    itemViewHeight: PropTypes.number,
+    itemViewWidth: PropTypes.number,
     sortingEnabled: PropTypes.bool,
     scrollEnabled: PropTypes.bool,
     horizontal: PropTypes.bool,
@@ -45,8 +45,8 @@ export default class SortableList extends Component {
     sortingEnabled: true,
     scrollEnabled: true,
     autoscrollAreaSize: 60,
-    draggableScreenHeight: 0,
-    draggableScreenWidth: 0,
+    itemViewHeight: 0,
+    itemViewWidth: 0,
     manuallyActivateRows: false,
     showsVerticalScrollIndicator: true,
     showsHorizontalScrollIndicator: true
@@ -188,12 +188,12 @@ export default class SortableList extends Component {
   }
 
   render() {
-    let {contentContainerStyle, innerContainerStyle, horizontal, style, showsVerticalScrollIndicator, showsHorizontalScrollIndicator, draggableScreenHeight, draggableScreenWidth} = this.props;
+    let {contentContainerStyle, innerContainerStyle, horizontal, style, showsVerticalScrollIndicator, showsHorizontalScrollIndicator, itemViewHeight, itemViewWidth} = this.props;
     const {animated, contentHeight, contentWidth, scrollEnabled} = this.state;
     const containerStyle = StyleSheet.flatten([style, {opacity: Number(animated)}])
     innerContainerStyle = [
       styles.rowsContainer,
-      horizontal ? {width: Math.max(contentWidth, draggableScreenWidth)} : {height: Math.max(contentHeight, draggableScreenHeight)},
+      horizontal ? {width: Math.max(contentWidth, itemViewWidth)} : {height: Math.max(contentHeight, itemViewHeight)},
       innerContainerStyle
     ];
     let {refreshControl} = this.props;


### PR DESCRIPTION
I got stuck into a problem that if the list only contains few items, when I drag the last item down, it will be disappeared from the list because the container height in `innerContainerStyle` is set to all items' size.

I suggest using: `itemViewHeight` (or `itemViewWidth` in horizontal mode) to control the inner container height when the list's height is smaller than the view size.
