### PR TITLE
Adds conditional rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.log
 node_modules
+*.idea

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -110,13 +110,21 @@ export default class SortableList extends Component {
           this._resolveRowLayout[key] = resolve;
         });
       });
-      this.setState({
-        animated: false,
-        data: nextData,
-        containerLayout: null,
-        rowsLayouts: null,
-        order: nextOrder
-      });
+
+      if (Object.keys(nextData).length > Object.keys(data).length) {
+        this.setState({
+          animated: false,
+          data: nextData,
+          containerLayout: null,
+          rowsLayouts: null,
+          order: nextOrder
+        });
+      } else {
+        this.setState({
+          data: nextData,
+          order: nextOrder
+        });
+      }
 
     } else if (order && nextOrder && !shallowEqual(order, nextOrder)) {
       this.setState({order: nextOrder});


### PR DESCRIPTION
Implements modified version of the workaround posted in [this comment](https://github.com/gitim/react-native-sortable-list/issues/47#issuecomment-368285671).

This should cause the component to only flash when a new element is added to the data. Modifying existing data should not trigger the entire component to re-render, which was causing the screen "flash" that was referenced in several issues.