### PR TITLE
Support deleting data from the list & add support for keyboardShouldPersistTaps prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ npm i react-native-sortable-list --save
 - **showsHorizontalScrollIndicator** (boolean) when false, the horizontal scroll indicator will not be visible. The default value is true.
 - **sortingEnabled?** (boolean) when false, rows are not sortable. The default value is true.
 - **scrollEnabled?** (boolean) when false, the content does not scrollable. The default value is true.
+- **keyboardShouldPersistTaps** (string)<br />
+Determines when the keyboard should stay visible after a tap.
+  - 'never' (the default), tapping outside of the focused text input when the keyboard is up dismisses the keyboard. When this happens, children won't receive the tap.
+  - 'always', the keyboard will not dismiss automatically, and the scroll view will not catch taps, but children of the scroll view can catch taps.
+  - 'handled', the keyboard will not dismiss automatically when the tap was handled by a children, (or captured by an ancestor.<br/>
 - **manuallyActivateRows?** (bool) whether you intend to use the `toggleRowActive` method to activate a row or use the out of box solution.
 - **autoscrollAreaSize?** (number) determines the height for vertical list and the width for horizontal list of the area at the begining and the end of the list that will trigger autoscrolling. Defaults to 60.<br />
 - **rowActivationTime?** (number) determines time delay in ms before pressed row becomes active. Defaults to 200 ms.<br />

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -29,6 +29,7 @@ export default class SortableList extends Component {
     autoscrollAreaSize: PropTypes.number,
     rowActivationTime: PropTypes.number,
     manuallyActivateRows: PropTypes.bool,
+    keyboardShouldPersistTaps: PropTypes.oneOf(['never', 'always', 'handled']),
 
     renderRow: PropTypes.func.isRequired,
     renderHeader: PropTypes.func,
@@ -42,6 +43,7 @@ export default class SortableList extends Component {
   static defaultProps = {
     sortingEnabled: true,
     scrollEnabled: true,
+    keyboardShouldPersistTaps: 'never',
     autoscrollAreaSize: 60,
     manuallyActivateRows: false,
     showsVerticalScrollIndicator: true,
@@ -184,7 +186,7 @@ export default class SortableList extends Component {
   }
 
   render() {
-    let {contentContainerStyle, innerContainerStyle, horizontal, style, showsVerticalScrollIndicator, showsHorizontalScrollIndicator} = this.props;
+    let {contentContainerStyle, innerContainerStyle, horizontal, style, showsVerticalScrollIndicator, showsHorizontalScrollIndicator, keyboardShouldPersistTaps} = this.props;
     const {animated, contentHeight, contentWidth, scrollEnabled} = this.state;
     const containerStyle = StyleSheet.flatten([style, {opacity: Number(animated)}])
     innerContainerStyle = [
@@ -209,6 +211,7 @@ export default class SortableList extends Component {
           contentContainerStyle={contentContainerStyle}
           scrollEventThrottle={2}
           scrollEnabled={scrollEnabled}
+          keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           showsHorizontalScrollIndicator={showsHorizontalScrollIndicator}
           showsVerticalScrollIndicator={showsVerticalScrollIndicator}
           onScroll={this._onScroll}>

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -111,21 +111,13 @@ export default class SortableList extends Component {
         });
       });
 
-      if (Object.keys(nextData).length > Object.keys(data).length) {
-        this.setState({
-          animated: false,
-          data: nextData,
-          containerLayout: null,
-          rowsLayouts: null,
-          order: nextOrder
-        });
-      } else {
-        this.setState({
-          data: nextData,
-          order: nextOrder
-        });
-      }
-
+      this.setState({
+        animated: false,
+        data: nextData,
+        containerLayout: null,
+        rowsLayouts: null,
+        order: nextOrder
+      });
     } else if (order && nextOrder && !shallowEqual(order, nextOrder)) {
       this.setState({order: nextOrder});
     }


### PR DESCRIPTION
Right now, the sortable list only updates its layout if the new data's length is larger than the previous data. On deletion, the sortable list should still update its layout. 

Also, I added and documented the functionality to pass keyboardShouldPersistTaps through to the scroll view.