### PR TITLE
Resize scrollview container when data changes

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -110,21 +110,13 @@ export default class SortableList extends Component {
           this._resolveRowLayout[key] = resolve;
         });
       });
-
-      if (Object.keys(nextData).length > Object.keys(data).length) {
-        this.setState({
-          animated: false,
-          data: nextData,
-          containerLayout: null,
-          rowsLayouts: null,
-          order: nextOrder
-        });
-      } else {
-        this.setState({
-          data: nextData,
-          order: nextOrder
-        });
-      }
+      this.setState({
+        animated: false,
+        data: nextData,
+        containerLayout: null,
+        rowsLayouts: null,
+        order: nextOrder
+      });
 
     } else if (order && nextOrder && !shallowEqual(order, nextOrder)) {
       this.setState({order: nextOrder});


### PR DESCRIPTION
This removes the condition that `nextData` length be > current data for the container size to be recalculated, which is important when scrolling is disabled (i.e. the list does not take up the full size of its container) and items are deleted from it.