### PR TITLE
fix rowsLayouts[key] is undefined trigger height is undefined crash

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -242,7 +242,7 @@ export default class SortableList extends Component {
       const style = {[ZINDEX]: 0};
       const location = {x: 0, y: 0};
 
-      if (rowsLayouts) {
+      if (rowsLayouts && rowsLayouts[key]) {
         if (horizontal) {
           location.x = nextX;
           nextX += rowsLayouts[key] ? rowsLayouts[key].width : 0;


### PR DESCRIPTION
when quickly add two or more rows to sortable-list,  _rowsLayouts is handle in _onUpdateLayouts with Promise;  Promise will cause order.length != rowsLayouts.lenght, and cause rowsLayouts[rowKey].height in _renderRow;