### PR TITLE
Expose more props for added flexability

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -136,11 +136,14 @@ export default class SortableList extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const {data} = this.state;
+    const {data, scrollEnabled} = this.state;
     const {data: prevData} = prevState;
 
     if (data && prevData && !shallowEqual(data, prevData)) {
       this._onUpdateLayouts();
+    }
+    if (prevProps.scrollEnabled !== scrollEnabled) {
+      this.setState({scrollEnabled: prevProps.scrollEnabled})
     }
   }
 

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -37,6 +37,7 @@ export default class SortableList extends Component {
     onChangeOrder: PropTypes.func,
     onActivateRow: PropTypes.func,
     onReleaseRow: PropTypes.func,
+    onScroll: PropTypes.func,
   };
 
   static defaultProps = {
@@ -45,7 +46,8 @@ export default class SortableList extends Component {
     autoscrollAreaSize: 60,
     manuallyActivateRows: false,
     showsVerticalScrollIndicator: true,
-    showsHorizontalScrollIndicator: true
+    showsHorizontalScrollIndicator: true,
+    onScroll: () => {}
   }
 
   /**
@@ -621,8 +623,9 @@ export default class SortableList extends Component {
     }
   };
 
-  _onScroll = ({nativeEvent: {contentOffset}}) => {
-      this._contentOffset = contentOffset;
+  _onScroll = (e) => {
+      this._contentOffset = e.nativeEvent.contentOffset;
+      this.props.onScroll(e)
   };
 
   _onRefContainer = (component) => {

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -49,6 +49,9 @@ export default class SortableList extends Component {
     manuallyActivateRows: false,
     showsVerticalScrollIndicator: true,
     showsHorizontalScrollIndicator: true,
+    scrollEventThrottle: 2,
+    decelerationRate: 'normal',
+    pagingEnabled: false,
     onScroll: () => {}
   }
 
@@ -199,7 +202,18 @@ export default class SortableList extends Component {
   }
 
   render() {
-    let {contentContainerStyle, innerContainerStyle, horizontal, style, showsVerticalScrollIndicator, showsHorizontalScrollIndicator, snapToAlignment} = this.props;
+    let {
+      contentContainerStyle, 
+      innerContainerStyle, 
+      horizontal, 
+      style, 
+      showsVerticalScrollIndicator, 
+      showsHorizontalScrollIndicator, 
+      snapToAlignment,
+      scrollEventThrottle,
+      decelerationRate,
+      pagingEnabled,
+    } = this.props;
     const {animated, contentHeight, contentWidth, scrollEnabled} = this.state;
     const containerStyle = StyleSheet.flatten([style, {opacity: Number(animated)}])
     innerContainerStyle = [
@@ -222,7 +236,9 @@ export default class SortableList extends Component {
           ref={this._onRefScrollView}
           horizontal={horizontal}
           contentContainerStyle={contentContainerStyle}
-          scrollEventThrottle={2}
+          scrollEventThrottle={scrollEventThrottle}
+          pagingEnabled={pagingEnabled}
+          decelerationRate={decelerationRate}
           scrollEnabled={scrollEnabled}
           showsHorizontalScrollIndicator={showsHorizontalScrollIndicator}
           showsVerticalScrollIndicator={showsVerticalScrollIndicator}

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -27,6 +27,7 @@ export default class SortableList extends Component {
     showsHorizontalScrollIndicator: PropTypes.bool,
     refreshControl: PropTypes.element,
     autoscrollAreaSize: PropTypes.number,
+    snapToAlignment: PropTypes.string,
     rowActivationTime: PropTypes.number,
     manuallyActivateRows: PropTypes.bool,
 
@@ -44,6 +45,7 @@ export default class SortableList extends Component {
     sortingEnabled: true,
     scrollEnabled: true,
     autoscrollAreaSize: 60,
+    snapToAlignment: 'start',
     manuallyActivateRows: false,
     showsVerticalScrollIndicator: true,
     showsHorizontalScrollIndicator: true,
@@ -194,7 +196,7 @@ export default class SortableList extends Component {
   }
 
   render() {
-    let {contentContainerStyle, innerContainerStyle, horizontal, style, showsVerticalScrollIndicator, showsHorizontalScrollIndicator} = this.props;
+    let {contentContainerStyle, innerContainerStyle, horizontal, style, showsVerticalScrollIndicator, showsHorizontalScrollIndicator, snapToAlignment} = this.props;
     const {animated, contentHeight, contentWidth, scrollEnabled} = this.state;
     const containerStyle = StyleSheet.flatten([style, {opacity: Number(animated)}])
     innerContainerStyle = [
@@ -221,7 +223,9 @@ export default class SortableList extends Component {
           scrollEnabled={scrollEnabled}
           showsHorizontalScrollIndicator={showsHorizontalScrollIndicator}
           showsVerticalScrollIndicator={showsVerticalScrollIndicator}
-          onScroll={this._onScroll}>
+          snapToAlignment={snapToAlignment}
+          onScroll={this._onScroll}
+        >
           {this._renderHeader()}
           <View style={innerContainerStyle}>
             {this._renderRows()}

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -30,6 +30,9 @@ export default class SortableList extends Component {
     snapToAlignment: PropTypes.string,
     rowActivationTime: PropTypes.number,
     manuallyActivateRows: PropTypes.bool,
+    scrollEventThrottle: PropTypes.number,
+    decelerationRate: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+    pagingEnabled: PropTypes.bool,
 
     renderRow: PropTypes.func.isRequired,
     renderHeader: PropTypes.func,


### PR DESCRIPTION
I inherited an app at my job and apparently we were using a forked version of this repo.
We had a bug that was crashing the app. 
To fix it I forked your repo again because of all the new changes and reapplied his changes. 
That fixed our app. 
Now something feels off about using this forked repo in our app. 
It would be nice to have these props exposed in the official package to remove our enterprise (hacky) workaround. 

All of the exposed props have been set to the react native defaults.