### PR TITLE
Notify 

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -340,7 +340,9 @@ export default class SortableList extends Component {
             contentWidth,
           }, () => {
             this.setState({animated: true}, () => {
-              this.props.onLayout();
+              if (this.props.onLayout) {
+                this.props.onLayout();
+              }
             });
           });
         });

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -36,6 +36,7 @@ export default class SortableList extends Component {
 
     onChangeOrder: PropTypes.func,
     onActivateRow: PropTypes.func,
+    onLayout: PropTypes.func,
     onReleaseRow: PropTypes.func,
   };
 
@@ -338,7 +339,9 @@ export default class SortableList extends Component {
             contentHeight,
             contentWidth,
           }, () => {
-            this.setState({animated: true});
+            this.setState({animated: true}, () => {
+              this.props.onLayout();
+            });
           });
         });
       });


### PR DESCRIPTION
because `_onUpdateLayouts` uses async callbacks to update layout, it causes UI clunking on initial render of the sortable list. This callback should mitigate weirdness on initial render.