### PR TITLE
Add ability to send in height or width of the item

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm i react-native-sortable-list --save
 
 ### API
 #### Props
-- **data** (Object) data source
+- **data** (Object|Item[]) data source
 - **order?** (Array) an array of keys from data, the order of keys from the array will be used to initial rows order
 - **style?** (Object, Array)
 - **contentContainerStyle?** (Object, Array) these styles will be applied to the inner scroll view content container
@@ -66,6 +66,11 @@ Called when the active row was released. Returns the key and the new list order.
 - **onPressRow?** (function)<br />
 `(key) => void`<br />
 Called when a row was pressed.
+
+#### Item
+These are the optional values you can send in the single object of a data source that would modify the way `react-native-sortable-list` would interact with it.
+- **height?** (Number) height of the item. overrides calculations
+- **width?** (Number) width of the item. overrides calculations
 
 #### Methods
 - **scrollBy(dy?, animated?)** scrolls by a given y offset, either immediately or with a smooth animation

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -283,10 +283,14 @@ export default class SortableList extends Component {
       if (rowsLayouts) {
         if (horizontal) {
           location.x = nextX;
-          nextX += rowsLayouts[key] ? rowsLayouts[key].width : 0;
+
+          let width = item.width != null ? item.width : 0;
+          nextX += (width === 0 && rowsLayouts[key]) ? rowsLayouts[key].width : width;
         } else {
           location.y = nextY;
-          nextY += rowsLayouts[key] ? rowsLayouts[key].height : 0;
+
+          let height = item.height != null ? item.height : 0;
+          nextY += (height === 0 && rowsLayouts[key]) ? rowsLayouts[key].height : height;
         }
       }
 


### PR DESCRIPTION
The feature came from a necessity of having different height items. When that happened, sorting the list would cause discrepancies in size because it was checking the `rowsLayout` with an old height. This helps base the height on something we might already have at the data level. The PR could still benefit from overriding the `rowsLayout` item itself since it would be more performant aswell to not calculate these values when we already have them but I'm new to the project and I implemented the MVP.

Here is an example usage:
```
const data = [
  { text: 'Foo', height: 10 },
  { text: 'Bar' }
];
```

The first data item would have a height as the basis and the second would one would be calculated.