### PR TITLE
Fix Proptype for `SortableList` `decelerationRate` prop

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -32,7 +32,7 @@ export default class SortableList extends Component {
     manuallyActivateRows: PropTypes.bool,
     keyboardShouldPersistTaps: PropTypes.oneOf(['never', 'always', 'handled']),
     scrollEventThrottle: PropTypes.number,
-    decelerationRate: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+    decelerationRate: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     pagingEnabled: PropTypes.bool,
     nestedScrollEnabled: PropTypes.bool,
     disableIntervalMomentum: PropTypes.bool,


### PR DESCRIPTION
Why?

There is an incorrect warning about proptypes in the `SortableList`
where the `decelerationRate` proptype is using `PropTypes.oneOf([...])`
instead of `PropTypes.oneOfType()`.

Changes:

Update the proptype to use `PropTypes.oneOfType()`.