### PR TITLE
Fix list height not readjusting if elements are removed.

### DIFF
--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -307,7 +307,7 @@ export default class SortableList extends Component {
           disabled={!sortingEnabled}
           style={style}
           location={location}
-          onLayout={!rowsLayouts ? this._onLayoutRow.bind(this, key) : null}
+          onLayout={this._onLayoutRow.bind(this, key)}
           onActivate={this._onActivateRow.bind(this, key, index)}
           onPress={this._onPressRow.bind(this, key)}
           onRelease={this._onReleaseRow.bind(this, key)}


### PR DESCRIPTION
Say we have a long list like this, and we want to shorten it with a "Hide" button which will pass only half of the data to the list:
![image](https://user-images.githubusercontent.com/12664722/80488077-79b81c80-8966-11ea-8b4f-e4c206cf0576.png)

After clicking hide, our elements disappeared, however list size hasn't re-adjusted, leaving us with lots of whitespace:
![image](https://user-images.githubusercontent.com/12664722/80488334-d4517880-8966-11ea-8a01-cb17379d3faa.png)

It seems that `onLayout` for rows is called only once, so after initial load we don't recalculate list height in `_onUpdateLayouts` on line 356. This PR seems to fix this.