### PR TITLE
Optionally disable specific rows

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -142,10 +142,11 @@ export default class Row extends Component {
     },
   });
 
-  componentWillReceiveProps(nextProps) {
-    if (!this._active && !shallowEqual(this._location, nextProps.location)) {
-      const animated = !this._active && nextProps.animated;
-      this._relocate(nextProps.location, animated);
+  componentDidUpdate() {
+    const {animated, location} = this.props;
+
+    if (!this._active && !shallowEqual(this._location, location)) {
+      this._relocate(location, !this._active && animated);
     }
   }
 

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -32,7 +32,7 @@ export default class SortableList extends Component {
     manuallyActivateRows: PropTypes.bool,
     keyboardShouldPersistTaps: PropTypes.oneOf(['never', 'always', 'handled']),
     scrollEventThrottle: PropTypes.number,
-    decelerationRate: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+    decelerationRate: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     pagingEnabled: PropTypes.bool,
     nestedScrollEnabled: PropTypes.bool,
     disableIntervalMomentum: PropTypes.bool,

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -45,6 +45,8 @@ export default class SortableList extends Component {
     onActivateRow: PropTypes.func,
     onReleaseRow: PropTypes.func,
     onScroll: PropTypes.func,
+
+    rowIsDisabled: PropTypes.func,
   };
 
   static defaultProps = {
@@ -289,6 +291,14 @@ export default class SortableList extends Component {
 
       const active = activeRowKey === key;
       const released = releasedRowKey === key;
+      const disabled = this.props.rowIsDisabled
+        ? this.props.rowIsDisabled({
+            key,
+            data: data[key],
+            active,
+            index,
+          })
+        : !sortingEnabled;
 
       if (active || released) {
         style[ZINDEX] = 100;
@@ -301,7 +311,7 @@ export default class SortableList extends Component {
           horizontal={horizontal}
           activationTime={rowActivationTime}
           animated={animated && !active}
-          disabled={!sortingEnabled}
+          disabled={disabled}
           style={style}
           location={location}
           onLayout={!rowsLayouts ? this._onLayoutRow.bind(this, key) : null}
@@ -313,7 +323,7 @@ export default class SortableList extends Component {
           {renderRow({
             key,
             data: data[key],
-            disabled: !sortingEnabled,
+            disabled,
             active,
             index,
           })}

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -88,7 +88,7 @@ export default class SortableList extends Component {
     scrollEnabled: this.props.scrollEnabled
   };
 
-  componentWillMount() {
+  componentDidMount() {
     this.state.order.forEach((key) => {
       this._rowsLayouts[key] = new Promise((resolve) => {
         this._resolveRowLayout[key] = resolve;
@@ -100,20 +100,20 @@ export default class SortableList extends Component {
         this._resolveHeaderLayout = resolve;
       });
     }
+
     if (this.props.renderFooter && !this.props.horizontal) {
       this._footerLayout = new Promise((resolve) => {
         this._resolveFooterLayout = resolve;
       });
     }
-  }
 
-  componentDidMount() {
     this._onUpdateLayouts();
   }
 
-  componentWillReceiveProps(nextProps) {
-    const {data, order} = this.state;
-    let {data: nextData, order: nextOrder} = nextProps;
+  componentDidUpdate(prevProps, prevState) {
+    const {data, order, scrollEnabled} = this.state;
+    let {data: nextData, order: nextOrder} = this.props;
+    const {data: prevData} = prevState;
 
     if (data && nextData && !shallowEqual(data, nextData)) {
       nextOrder = nextOrder || Object.keys(nextData)
@@ -143,11 +143,6 @@ export default class SortableList extends Component {
     } else if (order && nextOrder && !shallowEqual(order, nextOrder)) {
       this.setState({order: nextOrder});
     }
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    const {data, scrollEnabled} = this.state;
-    const {data: prevData} = prevState;
 
     if (data && prevData && !shallowEqual(data, prevData)) {
       this._onUpdateLayouts();

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -152,9 +152,11 @@ export default class SortableList extends Component {
     if (data && prevData && !shallowEqual(data, prevData)) {
       this._onUpdateLayouts();
     }
-    if (prevProps.scrollEnabled !== scrollEnabled) {
-      this.setState({scrollEnabled: prevProps.scrollEnabled})
-    }
+
+    // See https://github.com/gitim/react-native-sortable-list/issues/188
+    // if (prevProps.scrollEnabled !== scrollEnabled) {
+    //   this.setState({scrollEnabled: prevProps.scrollEnabled});
+    // }
   }
 
   scrollBy({dx = 0, dy = 0, animated = false}) {


### PR DESCRIPTION
This PR adds an optional prop that allows the consumer to disable specific rows. This function prop has the same signature as `renderRow` except that the `disabled` state is not provided in the argument.