### PR TITLE
Remove deprecated ViewPropTypes

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -1,6 +1,6 @@
 import React, {Component, cloneElement} from 'react';
 import PropTypes from 'prop-types';
-import {Animated, PanResponder, StyleSheet, ViewPropTypes} from 'react-native';
+import {Animated, PanResponder, StyleSheet} from 'react-native';
 import {shallowEqual} from './utils';
 
 export default class Row extends Component {
@@ -9,7 +9,7 @@ export default class Row extends Component {
     animated: PropTypes.bool,
     disabled: PropTypes.bool,
     horizontal: PropTypes.bool,
-    style: ViewPropTypes.style,
+    style: PropTypes.object,
     location: PropTypes.shape({
       x: PropTypes.number,
       y: PropTypes.number,

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -13,13 +13,17 @@ function uniqueRowKey(key) {
 
 uniqueRowKey.id = 0
 
+// react-native seems to sometimes represent stylesheet entries as numbers, and sometimes as objects.
+// See: https://stackoverflow.com/questions/41483862/how-are-styles-mapped-to-numbers-in-react-native
+const STYLE_TYPE = PropTypes.oneOfType([PropTypes.number, PropTypes.object])
+
 export default class SortableList extends Component {
   static propTypes = {
     data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
     order: PropTypes.arrayOf(PropTypes.any),
-    style: PropTypes.number,
-    contentContainerStyle: PropTypes.object,
-    innerContainerStyle: PropTypes.object,
+    style: STYLE_TYPE,
+    contentContainerStyle: STYLE_TYPE,
+    innerContainerStyle: STYLE_TYPE,
     sortingEnabled: PropTypes.bool,
     scrollEnabled: PropTypes.bool,
     horizontal: PropTypes.bool,

--- a/src/SortableList.js
+++ b/src/SortableList.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {ScrollView, View, StyleSheet, Platform, RefreshControl, ViewPropTypes} from 'react-native';
+import {ScrollView, View, StyleSheet, Platform, RefreshControl} from 'react-native';
 import {shallowEqual, swapArrayElements} from './utils';
 import Row from './Row';
 
@@ -17,9 +17,9 @@ export default class SortableList extends Component {
   static propTypes = {
     data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
     order: PropTypes.arrayOf(PropTypes.any),
-    style: ViewPropTypes.style,
-    contentContainerStyle: ViewPropTypes.style,
-    innerContainerStyle: ViewPropTypes.style,
+    style: PropTypes.number,
+    contentContainerStyle: PropTypes.object,
+    innerContainerStyle: PropTypes.object,
     sortingEnabled: PropTypes.bool,
     scrollEnabled: PropTypes.bool,
     horizontal: PropTypes.bool,
@@ -32,7 +32,7 @@ export default class SortableList extends Component {
     manuallyActivateRows: PropTypes.bool,
     keyboardShouldPersistTaps: PropTypes.oneOf(['never', 'always', 'handled']),
     scrollEventThrottle: PropTypes.number,
-    decelerationRate: PropTypes.oneOf([PropTypes.string, PropTypes.number]),
+    decelerationRate: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     pagingEnabled: PropTypes.bool,
     nestedScrollEnabled: PropTypes.bool,
     disableIntervalMomentum: PropTypes.bool,


### PR DESCRIPTION
Hi, thanks for `react-native-sortable-list`.

`ViewPropTypes` is no longer available in `react-native-web`, following a deprecation period. The removal was announced at: https://github.com/necolas/react-native-web/releases/tag/0.12.0 .

When I experimented with v0.0.24, I was unable to run this package due to use of `ViewPropTypes` , and this PR shows how I patched it to get it to work again.