### PR TITLE
Pass panHandlers to row component

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -59,7 +59,7 @@ export default class Row extends Component {
       // Returns whether this component should block native components from becoming the JS
       // responder. Returns true by default. Is currently only supported on android.
       // NOTE: Returning false here allows us to scroll unless it's a long press on a row.
-      return false;
+      return true;
     },
 
     onPanResponderGrant: (e, gestureState) => {
@@ -172,14 +172,13 @@ export default class Row extends Component {
 
     return (
       <Animated.View
-        {...this._panResponder.panHandlers}
         style={rowStyle}
         onLayout={this._onLayout}>
-        {this.props.manuallyActivateRows && children
-          ? cloneElement(children, {
-            toggleRowActive: this._toggleActive,
+        {children &&
+          cloneElement(children, {
+            toggleRowActive: this.props.manuallyActivateRows ? this._toggleActive: undefined,
+            panHandlers: this._panResponder.panHandlers
           })
-          : children
         }
       </Animated.View>
     );


### PR DESCRIPTION
This allows developers to set the pan handlers on a specific view inside the item.
I especially needed this because my items are full width and the scroll view on android kept stealing the touch events.