### PR TITLE
Update deprecated RN lifecycle methods and fix prop type typo.

### DIFF
--- a/examples/Basic/App.js
+++ b/examples/Basic/App.js
@@ -120,12 +120,12 @@ class Row extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.active !== nextProps.active) {
+  componentDidUpdate(prevProps) {
+    if (this.props.active !== prevProps.active) {
       Animated.timing(this._active, {
         duration: 300,
         easing: Easing.bounce,
-        toValue: Number(nextProps.active),
+        toValue: Number(this.props.active),
       }).start();
     }
   }

--- a/examples/Horizontal/App.js
+++ b/examples/Horizontal/App.js
@@ -121,12 +121,12 @@ class Row extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.active !== nextProps.active) {
+  componentDidUpdate(prevProps) {
+    if (this.props.active !== prevProps.active) {
       Animated.timing(this._active, {
         duration: 300,
         easing: Easing.bounce,
-        toValue: Number(nextProps.active),
+        toValue: Number(this.props.active),
       }).start();
     }
   }

--- a/src/Row.js
+++ b/src/Row.js
@@ -142,10 +142,10 @@ export default class Row extends Component {
     },
   });
 
-  componentWillReceiveProps(nextProps) {
-    if (!this._active && !shallowEqual(this._location, nextProps.location)) {
-      const animated = !this._active && nextProps.animated;
-      this._relocate(nextProps.location, animated);
+  componentDidUpdate() {
+    if (!this._active && !shallowEqual(this._location, this.props.location)) {
+      const animated = !this._active && this.props.animated;
+      this._relocate(this.props.location, animated);
     }
   }
 


### PR DESCRIPTION
Fixes #206.
Fixes #201.
Fixes #193.
Fixes #167.

Updated `componentWillMount` to `componentDidMount` and `componentWillReceiveProps` to `componentDidUpdate`.

Also fixed typo in `SortableList.js`: `oneOf` —> `oneOfType`. This was causing a warning for an invalid prop type for the `decerationRate` prop.