### PR TITLE
Animated 'useNativeDriver' option compatibility

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -197,6 +197,7 @@ export default class Row extends Component {
       Animated.timing(this._animatedLocation, {
         toValue: nextLocation,
         duration: 300,
+        useNativeDriver: false,
       }).start(() => {
         this._isAnimationRunning = false;
       });


### PR DESCRIPTION
Defining a `useNativeDriver` value for `Animated.timing` is now required, and raise a warning in projects that doesn't set it correctly. Fixing this issue.  
For more info, see https://github.com/facebook/react-native/issues/28558